### PR TITLE
updated view title

### DIFF
--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -39,6 +39,7 @@ export default {
   watch: {
     name(newVal) {
       this.getRecipe(newVal);
+      window.document.title = `Open Drinks - ${this.drink.name}`
     },
   },
   data() {
@@ -49,6 +50,7 @@ export default {
   },
   created() {
     this.getRecipe(this.name);
+    window.document.title = `Open Drinks - ${this.drink.name}`
   },
   methods: {
     getRecipe(name) {

--- a/src/components/RecipeFind.vue
+++ b/src/components/RecipeFind.vue
@@ -38,6 +38,7 @@ export default {
   created() {
     const data = recipes.getRecipes();
     this.data = data;
+    window.document.title = 'Open Drinks - Search'
   },
   methods: {
     onEnter() {

--- a/src/components/RecipeList.vue
+++ b/src/components/RecipeList.vue
@@ -36,6 +36,7 @@ export default {
   },
   mounted() {
     this.getDrinks();
+    window.document.title = 'Open Drinks - Explore'
   },
   methods: {
     getDrinks() {


### PR DESCRIPTION
Document Title has now been updated for clarity:
- `Recipe` now displays `🍸 Open Drinks - ${drink name}`
- `RecipeFind` now displays `🍸 Open Drinks - Search`
- `RecipeList` now displays `🍸 Open Drinks - Explore`