### PR TITLE
Lazy Load Pages to Reduce Initial Bundle Size

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -1,9 +1,5 @@
 import Vue from 'vue';
 import Router from 'vue-router';
-import Home from './views/Home.vue';
-import Recipe from './views/Recipe.vue';
-import Explore from './views/Explore.vue';
-import Search from './views/Search.vue';
 
 Vue.use(Router);
 
@@ -14,22 +10,22 @@ export default new Router({
     {
       path: '/',
       name: 'home',
-      component: Home,
+      component: () => import('./views/Home.vue'),
     },
     {
       path: '/recipe/:id',
       name: 'recipe',
-      component: Recipe,
+      component: () => import('./views/Recipe.vue'),
     },
     {
       path: '/explore',
       name: 'explore',
-      component: Explore,
+      component: () => import('./views/Explore.vue'),
     },
     {
       path: '/search',
       name: 'search',
-      component: Search,
+      component: () => import('./views/Search.vue'),
     },
     {
       path: '/about',


### PR DESCRIPTION
### Description

I have added lazy loading to reduce the initial bundle size that the user needs to download on initial page load.

I have used webpack bundle analyzer to show the massive performance gains.

### Proof

First, without lazy loading, all pages are in one webpack chunk located in the blue chunk below.

![notlazyload](https://user-images.githubusercontent.com/8920897/66009053-dc0b7600-e486-11e9-9491-2d9dc0bc0a7f.PNG)


After applying this fix, you can see these new light blue chunks can be independently loaded on request.

![lazyload](https://user-images.githubusercontent.com/8920897/66009092-02c9ac80-e487-11e9-9f08-5874dafc9cf0.PNG)
