### PR TITLE
Add fuzzy search against names/ingredients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5954,6 +5954,11 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "fuse.js": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.5.tgz",
+      "integrity": "sha512-s9PGTaQIkT69HaeoTVjwGsLfb8V8ScJLx5XGFcKHg0MqLUH/UZ4EKOtqtXX9k7AFqCGxD1aJmYb8Q5VYDibVRQ=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bootstrap": "^4.3.1",
     "bootstrap-vue": "^2.0.1",
     "core-js": "^2.6.5",
+    "fuse.js": "^3.4.5",
     "register-service-worker": "^1.6.2",
     "vue": "^2.6.10",
     "vue-router": "^3.0.3"

--- a/src/components/RecipeFind.vue
+++ b/src/components/RecipeFind.vue
@@ -16,6 +16,7 @@
 
 <script>
 import recipes from '../recipes';
+import Fuse from 'fuse.js';
 
 const limit = 10; // Limit filtered results.
 
@@ -23,22 +24,32 @@ export default {
   name: 'RecipeFind',
   data() {
     return {
-      data: [],
       search: '',
+      fuse: {},
     };
   },
   computed: {
     filterResults() {
-      const filtered = this.data.filter(item => (
-        item.name.toLowerCase().indexOf(this.search.toLowerCase()) > -1
-      ));
-      return filtered.slice(0, limit);
+      const res = this.fuse.search(this.search);
+      return res.slice(0, limit);
     },
   },
   created() {
     const data = recipes.getRecipes();
-    this.data = data;
     window.document.title = 'Open Drinks - Search';
+
+    this.fuse = new Fuse(data, {
+      shouldSort: true,
+      threshold: 0.6,
+      location: 0,
+      distance: 100,
+      maxPatternLength: 32,
+      minMatchCharLength: 1,
+      keys: [
+        { name: "name", weight: 0.75 },
+        { name: "ingredients", weight: 0.25 },
+      ]
+    });
   },
   methods: {
     onEnter() {

--- a/src/components/RecipeFind.vue
+++ b/src/components/RecipeFind.vue
@@ -30,8 +30,9 @@ export default {
   },
   computed: {
     filterResults() {
-      const res = this.fuse.search(this.search);
-      return res.slice(0, limit);
+      return this.fuse
+        .search(this.search)
+        .slice(0, limit);
     },
   },
   created() {
@@ -40,7 +41,7 @@ export default {
 
     this.fuse = new Fuse(data, {
       shouldSort: true,
-      threshold: 0.6,
+      threshold: 0.4,
       location: 0,
       distance: 100,
       maxPatternLength: 32,


### PR DESCRIPTION
Adds the fuse.js library so we can fuzzy search for drinks.

Addresses feature in Issue #102.

Names have more weight than ingredients.