### PR TITLE
Issue #190 Truncate recipe descriptions on "Explore" view

### DIFF
--- a/src/components/RecipeList.vue
+++ b/src/components/RecipeList.vue
@@ -100,4 +100,13 @@ export default {
 .card-deck .card {
   margin-right: 0;
 }
+.card-text {
+  display: block;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-height: 6rem;
+}
 </style>


### PR DESCRIPTION
Truncate recipe descriptions on "Explore" view using "-webkit-line-clamp" and "text-overflow: ellipsis" CSS options.