### PR TITLE
issue #195: css fix for card images

### DIFF
--- a/src/components/RecipeList.vue
+++ b/src/components/RecipeList.vue
@@ -109,4 +109,8 @@ export default {
   text-overflow: ellipsis;
   min-height: 6rem;
 }
+.card-img-top {
+  height: 212px;
+  object-fit: cover;
+}
 </style>


### PR DESCRIPTION
I gave all of the images a fixed height.

Images in the wrong aspect ratio will be cropped to fit in the border.

Fix for issue #195 