### PR TITLE
Updated tags from w-z recipes

### DIFF
--- a/src/recipes/watermelon-smoothie.json
+++ b/src/recipes/watermelon-smoothie.json
@@ -41,6 +41,7 @@
     "image": "watermelon-smoothie.jpg",
     "keywords": [
         "watermelon",
-        "non-alcoholic"
+        "non-alcoholic",
+        "smoothie"
     ]
 }

--- a/src/recipes/whisky-sour.json
+++ b/src/recipes/whisky-sour.json
@@ -37,6 +37,7 @@
     "keywords": [
         "alcoholic",
         "whiskey",
-        "egg"
+        "egg",
+        "cocktail"
     ]
 }

--- a/src/recipes/yellow-watermelon-juice.json
+++ b/src/recipes/yellow-watermelon-juice.json
@@ -36,6 +36,8 @@
     "keywords": [
         "ice",
         "fruit",
-        "juice"
+        "juice",
+        "smoothie",
+        "non-alcoholic"
     ]
 }

--- a/src/recipes/yogurt-fruit-shake.json
+++ b/src/recipes/yogurt-fruit-shake.json
@@ -55,6 +55,7 @@
     "source": "",
     "keywords": [
         "smoothie",
-        "fruit"
+        "fruit",
+        "non-alcoholic"
     ]
 }

--- a/src/recipes/zombie.json
+++ b/src/recipes/zombie.json
@@ -49,6 +49,7 @@
     "source": "https://gummy-bears-and-some-scotch.firebaseapp.com/drink?id=17241",
     "keywords": [
         "cocktail",
-        "rum"
+        "rum",
+        "alcoholic"
     ]
 }


### PR DESCRIPTION
Added some common tags used in other recipes to drinks named w-z for issue #139 .
- Tagged yogurt fruit shake to with "non-alcoholic".
- Added "non-alcoholic" and "smoothie" to yellow watermelon juice.
- Tagged watermelon smoothie as a "smoothie".
- Included "cocktail" tag to whisky-sour.
- Tagged zombie as "alcoholic".