### PR TITLE
Add simple test for App component. Also added a babel-plugin-require-…

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,8 @@
 module.exports = {
   presets: ['@vue/app'],
+  env: {
+    test: {
+      plugins: ['require-context-hook'],
+    },
+  },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
+  setupFiles: ['<rootDir>/tests/setup.js'],
   snapshotSerializers: ['jest-serializer-vue'],
   testMatch: ['**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)'],
   testURL: 'http://localhost/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2288,6 +2288,12 @@
         "resolve": "^1.4.0"
       }
     },
+    "babel-plugin-require-context-hook": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-require-context-hook/-/babel-plugin-require-context-hook-1.0.0.tgz",
+      "integrity": "sha512-EMZD1563QUqLhzrqcThk759RhuNVX/ZJdrtGK6drwzgvnR+ARjWyXIHPbu+tUNaMGtPz/gQeAM2M6VUw2UiUeA==",
+      "dev": true
+    },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
@@ -6180,8 +6186,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6202,14 +6207,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6224,20 +6227,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6354,8 +6354,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6367,7 +6366,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6382,7 +6380,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6390,14 +6387,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6416,7 +6411,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6497,8 +6491,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6510,7 +6503,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6596,8 +6588,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6633,7 +6624,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6653,7 +6643,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6697,14 +6686,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -12547,8 +12534,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -36,14 +36,15 @@
     "@vue/cli-plugin-unit-jest": "^3.11.0",
     "@vue/cli-service": "^3.11.0",
     "@vue/eslint-config-airbnb": "^4.0.0",
+    "@vue/eslint-config-prettier": "^5.0.0",
     "@vue/test-utils": "1.0.0-beta.29",
     "babel-core": "7.0.0-bridge.0",
-    "babel-jest": "^23.6.0",
-    "@vue/eslint-config-prettier": "^5.0.0",
     "babel-eslint": "^10.0.1",
+    "babel-jest": "^23.6.0",
+    "babel-plugin-require-context-hook": "^1.0.0",
     "eslint": "^6.5.1",
-    "eslint-plugin-vue": "^5.2.3",
     "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-vue": "^5.2.3",
     "prettier": "^1.18.2",
     "vue-template-compiler": "^2.6.10"
   }

--- a/src/components/RecipeTile.vue
+++ b/src/components/RecipeTile.vue
@@ -58,7 +58,7 @@ export default {
     croppedDescription() {
       const { description } = this.drink;
       const cropped = description.substring(0, MAX_DESCRIPTION_LENGTH);
-      return description.length > MAX_DESCRIPTION_LENGTH ? `${cropped} …` : description;
+      return description.length > MAX_DESCRIPTION_LENGTH ? `${cropped} ...` : description;
     },
   },
   created() {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,3 @@
+import registerRequireContextHook from 'babel-plugin-require-context-hook/register';
+
+registerRequireContextHook();

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -1,0 +1,16 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import BootstrapVue from 'bootstrap-vue';
+
+import router from '@/router';
+import App from '@/App.vue';
+
+const localVue = createLocalVue();
+
+localVue.use(BootstrapVue);
+
+describe('App', () => {
+  test('is a Vue instance', () => {
+    const wrapper = mount(App, { localVue, router });
+    expect(wrapper.isVueInstance()).toBeTruthy();
+  });
+});

--- a/tests/unit/components/Recipe.spec.js
+++ b/tests/unit/components/Recipe.spec.js
@@ -1,0 +1,20 @@
+import { createLocalVue, mount } from '@vue/test-utils';
+import BootstrapVue from 'bootstrap-vue';
+
+import router from '@/router';
+import Recipe from '@/components/Recipe.vue';
+
+const localVue = createLocalVue();
+
+localVue.use(BootstrapVue);
+
+describe('Recipe', () => {
+  test('is a Vue instance', () => {
+    const wrapper = mount(Recipe, {
+      propsData: { name: 'mango-juice.json' },
+      localVue,
+      router,
+    });
+    expect(wrapper.isVueInstance()).toBeTruthy();
+  });
+});


### PR DESCRIPTION
I found that `require.context` in the `src/recipes/index.js` loader was causing issues when running tests via Jest. This is because `require.context` is used by webpack. Adding the module `babel-plugin-require-context-hook` to babel for the test environment seems to work.

* Add simple test for App component. 
* Add simple test for Recipe component.
* Also added a babel-plugin-require context-hook to test environment so require.context can be handled in Jest.