### PR TITLE
Add 'load more' feature for recipes on the featured list.

### DIFF
--- a/src/components/FeaturedRecipes.vue
+++ b/src/components/FeaturedRecipes.vue
@@ -5,11 +5,20 @@
       <p>{{ feature.description }}</p>
       <b-card-group deck>
         <RecipeTile
-          v-for="(item, j) in feature.items.slice(0, featuredLimit)"
+          v-for="(item, j) in feature.items.slice(0, feature.size)"
           v-bind:key="j"
           v-bind:id="item"
         />
       </b-card-group>
+      <b-button
+        block
+        variant="outline-primary"
+        v-if="feature.items.length > featuredItemSize && feature.size < feature.items.length"
+        v-on:click="loadMore(i)"
+      >
+        Load More</b-button
+      >
+
       <hr v-if="featuredList.length !== i + 1" />
     </div>
   </div>
@@ -19,6 +28,8 @@
 import recipes from '../recipes';
 import RecipeTile from './RecipeTile.vue';
 
+const FEATURED_ITEM_SIZE = 6;
+
 export default {
   name: 'FeaturedRecipes',
   components: {
@@ -26,13 +37,18 @@ export default {
   },
   data() {
     return {
-      featuredLimit: 6,
       featuredList: [],
+      featuredItemSize: FEATURED_ITEM_SIZE,
     };
   },
   created() {
     window.document.title = `Open Drinks - Featured`;
     this.featuredList = recipes.getFeaturedRecipes();
+  },
+  methods: {
+    loadMore(i) {
+      this.featuredList[i].size += FEATURED_ITEM_SIZE;
+    },
   },
 };
 </script>

--- a/src/featured.json
+++ b/src/featured.json
@@ -6,7 +6,8 @@
             "mai-tai",
             "pineapple-juice",
             "bramble"
-        ]
+        ],
+        "size": 3
     },
     {
         "title": "Halloween Drinks",
@@ -19,7 +20,8 @@
             "corpse-reviver-no2",
             "cuban-zombie",
             "vampiro"
-        ]
+        ],
+        "size": 6
     },
     {
         "title": "Under the Weather Drinks",
@@ -43,6 +45,7 @@
             "rusty-nail",
             "sangria",
             "warm-lemon-honey-tea"
-        ]
+        ],
+        "size": 6
     }
 ]


### PR DESCRIPTION
Adding a feature where you can "load more" recipes on the featured recipes view. This is so we can add larger lists of recipes on the homepage categories, but limiting the category to 6 items, unless the user clicks to load more.