### PR TITLE
New Domain - opendrinks.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ The [/src/recipes/](/src/recipes/) directory contains all the drink recipes as a
 * source is an optional field
 * Submit a Pull Request with your recipe! 
 * An automated preview link will be generated towards the bottom of the PR so your changes can be previewed while in review.
-* Once approved and merged, the latest update will be published to https://opendrinks.netlify.com
+* Once approved and merged, the latest update will be published to https://opendrinks.io
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Open source drinks! Inspired by [🎃Hacktoberfest](https://hacktoberfest.digitalocean.com/)!
 
-https://opendrinks.netlify.com/
+https://opendrinks.io/
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/942bef4f-2873-4e49-91c6-c92373a4473e/deploy-status)](https://opendrinks.netlify.com)
 [![Build Status](https://travis-ci.org/alfg/opendrinks.svg?branch=master)](https://travis-ci.org/alfg/opendrinks)
@@ -21,7 +21,7 @@ See: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 - Check existing recipes in [/src/recipes](/src/recipes)
 - Fork and make a pull request with your drink recipe
-- Once your Pull Request is approved and merged, the latest update will be published to https://opendrinks.netlify.com
+- Once your Pull Request is approved and merged, the latest update will be published to https://opendrinks.io
 
 Also check out [Issues](https://github.com/alfg/opendrinks/issues) for any open bug fixes or feature requests!
 

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta name="Description" content="Open source drink recipes.">
-    <meta name="google-site-verification" content="KIXdbydVyiD44U3XHswfczQnq2PgdeI5J--9buLrPd4" />
+    <meta name="google-site-verification" content="sLglpHQ4Oc-ZwNSp6yhwKtSj5M9SEzokHXl2FhQdbQQ" />
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <link href='https://fonts.googleapis.com/css?family=Pacifico' rel='stylesheet' type='text/css'>
     <title>Open Drinks</title>

--- a/scripts/sitemap_generator.js
+++ b/scripts/sitemap_generator.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const { SitemapStream, streamToPromise } = require('sitemap');
 
-const HOSTNAME = 'https://opendrinks.netlify.com';
+const HOSTNAME = 'https://opendrinks.io';
 const SITEMAP_XML = 'dist/sitemap.xml';
 const PAGES = ['featured', 'random', 'explore', 'keywords', 'search'];
 

--- a/src/featured.json
+++ b/src/featured.json
@@ -131,7 +131,7 @@
       "bajigur",
       "banana-smoothie",
       "bandrek",
-      "barranquito",
+      "barraquito",
       "brazilian-strawberry-drink",
       "buttermilk",
       "chickoo_lassi",


### PR DESCRIPTION
Registered the domain `opendrinks.io`. Updating all references from `opendrinks.netlify.com` to `opendrinks.io`.