### PR TITLE
feat: added new empty favorites test

### DIFF
--- a/tests/unit/views/Favorites.spec.js
+++ b/tests/unit/views/Favorites.spec.js
@@ -7,7 +7,7 @@ import Favorites from '@/views/Favorites.vue';
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
 
-describe('Favorites', () => {
+describe('Favorites (Populated)', () => {
   let wrapper;
 
   beforeEach(() => {
@@ -32,5 +32,25 @@ describe('Favorites', () => {
     expect(wrapper.find('#star').trigger('click'));
     const favs = JSON.parse(localStorage.getItem('favorites'));
     expect(favs.length === 1).toBe(true);
+  });
+});
+
+describe('Favorites (Empty)', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(Favorites, {
+      localVue,
+      router,
+    });
+  });
+
+  test('show correct empty state', () => {
+    localStorage.setItem('favorites', JSON.stringify([]));
+    wrapper = mount(Favorites, {
+      localVue,
+      router,
+    });
+    expect(wrapper.find('.alert-info').html()).toContain("You don't have any favorite drinks");
   });
 });


### PR DESCRIPTION
This is a new test for the 'Favorites' page when nothing is favorited. It should display an alert saying 'You don't have any favorite drinks'.

Related issue #281