### PR TITLE
Add social sharing for recipe (facebook, twitter)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16193,6 +16193,11 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz",
       "integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
     },
+    "vue-social-sharing": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vue-social-sharing/-/vue-social-sharing-3.0.0.tgz",
+      "integrity": "sha512-lUIzS7wqLnxRaKCRyyfyWQcUlGFEZkT2aIdcndv3hApUA4JOV95sk/ubk9vNwVrY1bpqxnltaZGxsl9ikMlNFQ=="
+    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "netlify-lambda": "^1.6.3",
     "register-service-worker": "^1.6.2",
     "vue": "^2.6.10",
-    "vue-router": "^3.0.3"
+    "vue-router": "^3.0.3",
+    "vue-social-sharing": "^3.0.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.1.1",

--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -23,6 +23,32 @@
             Print
           </b-button>
         </div>
+        <div class="share-button">
+          <b-dropdown text="Share" variant="outline-primary" right class="m-2">
+            <b-dropdown-item>
+              <ShareNetwork
+                network="facebook"
+                :url="recipeAbsoluteURL"
+                :title="drink.name"
+                :description="drink.description"
+                :hashtags="drink.keywords.join()"
+              >
+                Share on Facebook
+              </ShareNetwork>
+            </b-dropdown-item>
+            <b-dropdown-item>
+              <ShareNetwork
+                network="twitter"
+                :url="recipeAbsoluteURL"
+                :title="drink.name"
+                :description="drink.description"
+                :hashtags="drink.keywords.join()"
+              >
+                Share on Twitter
+              </ShareNetwork>
+            </b-dropdown-item>
+          </b-dropdown>
+        </div>
       </div>
     </div>
 
@@ -101,6 +127,11 @@ export default {
   components: {
     RecipeTile,
     FavoriteStar,
+  },
+  computed: {
+    recipeAbsoluteURL() {
+      return `https://opendrinks.io${this.$route.fullPath}`;
+    },
   },
   watch: {
     name(newVal) {

--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -130,7 +130,7 @@ export default {
   },
   computed: {
     recipeAbsoluteURL() {
-      return `https://opendrinks.io${this.$route.fullPath}`;
+      return `https://opendrinks.io${window.location.pathname}`;
     },
   },
   watch: {

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import './assets/css/main.css';
 
 import Vue from 'vue';
 import BoostrapVue from 'bootstrap-vue';
+import VueSocialSharing from 'vue-social-sharing';
 import App from './App.vue';
 import router from './router';
 import './registerServiceWorker';
@@ -12,6 +13,7 @@ import 'core-js';
 Vue.config.productionTip = false;
 
 Vue.use(BoostrapVue);
+Vue.use(VueSocialSharing);
 
 new Vue({
   router,

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -1,5 +1,6 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import BootstrapVue from 'bootstrap-vue';
+import VueSocialSharing from 'vue-social-sharing';
 
 import router from '@/router';
 import App from '@/App.vue';
@@ -7,6 +8,7 @@ import App from '@/App.vue';
 const localVue = createLocalVue();
 
 localVue.use(BootstrapVue);
+localVue.use(VueSocialSharing);
 
 describe('App', () => {
   test('is a Vue instance', () => {

--- a/tests/unit/components/Recipe.spec.js
+++ b/tests/unit/components/Recipe.spec.js
@@ -1,5 +1,6 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import BootstrapVue from 'bootstrap-vue';
+import VueSocialSharing from 'vue-social-sharing';
 
 import router from '@/router';
 import Recipe from '@/components/Recipe.vue';
@@ -7,6 +8,7 @@ import Recipe from '@/components/Recipe.vue';
 const localVue = createLocalVue();
 
 localVue.use(BootstrapVue);
+localVue.use(VueSocialSharing);
 
 describe('Recipe', () => {
   const wrapper = shallowMount(Recipe, {

--- a/tests/unit/views/Random.spec.js
+++ b/tests/unit/views/Random.spec.js
@@ -1,5 +1,6 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import BootstrapVue from 'bootstrap-vue';
+import VueSocialSharing from 'vue-social-sharing';
 import Random from '@/views/Random.vue';
 
 describe('Random view', () => {
@@ -9,6 +10,7 @@ describe('Random view', () => {
   beforeEach(() => {
     const localVue = createLocalVue();
     localVue.use(BootstrapVue);
+    localVue.use(VueSocialSharing);
     fn = jest.fn();
 
     wrapper = mount(Random, {


### PR DESCRIPTION
## Added
Dropdown with social sharing options.
Introduced [vue-social-sharing](https://github.com/nicolasbeauvais/vue-social-sharing) package.

![recording](https://user-images.githubusercontent.com/11461961/95067713-7f2f4500-0704-11eb-84e9-9dcb39b278d6.gif)


| Supported sharing platforms in this PR |
|---------------------------------------|
| Facebook                              |
| Twitter                               |

Feel free to suggest additional platforms. Preferably from [this list](https://github.com/nicolasbeauvais/vue-social-sharing#networks)

Fixes #804 