### PR TITLE
Clean up missed angle brackets

### DIFF
--- a/src/recipes/bourbon-old-fashioned.json
+++ b/src/recipes/bourbon-old-fashioned.json
@@ -10,7 +10,7 @@
             "ingredient": "sugar"
         },
         {
-            "quantity": "1>",
+            "quantity": "1",
             "measure": "tsp",
             "ingredient": "water"
         },

--- a/src/recipes/jaljeera.json
+++ b/src/recipes/jaljeera.json
@@ -11,7 +11,7 @@
         },
         {
             "quantity": "6",
-            "measure": "tablespoon>",
+            "measure": "tablespoon",
             "ingredient": "lemon juice"
         },
         {
@@ -21,12 +21,12 @@
         },
         {
             "quantity": "8",
-            "measure": "cup>",
+            "measure": "cup",
             "ingredient": "water"
         },
         {
             "quantity": "2",
-            "measure": "tablespoon>",
+            "measure": "tablespoon",
             "ingredient": "cumin seeds"
         },
         {

--- a/src/recipes/noche-caliente.json
+++ b/src/recipes/noche-caliente.json
@@ -10,7 +10,7 @@
         },
         {
             "quantity": "2",
-            "measure": "teaspoon>",
+            "measure": "teaspoon",
             "ingredient": "lime juice"
         },
 		{

--- a/src/recipes/warm-lemon-honey-tea.json
+++ b/src/recipes/warm-lemon-honey-tea.json
@@ -15,7 +15,7 @@
         },
         {
             "quantity": "2",
-            "measure": "tablespoons>",
+            "measure": "tablespoons",
             "ingredient": "honey"
         }
     ],


### PR DESCRIPTION
I noticed some of the recipes had `>` symbols in their values that should not be there, so I went and cleaned them up.