### PR TITLE
Fix flash of light theme while switching recipes while in dark theme

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -5,19 +5,19 @@ svg{
   color: var(--main-bg-color) !important;
 }
 
-.list-group-item{
+.list-group-item {
   background-color: var(--main-bg-color);
   border: 1px solid var(--main-line-color);
   color: var(--main-text-color);
 }
 
-.list-group-item:hover{
+.list-group-item:hover {
   background-color: var(--main-bg-hover-color);
   border: 1px solid var(--main-line-color);
   color: var(--main-text-color);
 }
 
-.badge-primary{
+.badge-primary {
   background-color: var(--main-link-color);
   color: var(--main-bg-color);
 }
@@ -26,11 +26,11 @@ body {
   background-color: var(--main-bg-color);
 }
 
-h1,h2,h3,h4,h6,p {
+h1, h2, h3, h4, h6, p {
   color: var(--main-text-color);
 }
 
-a, a:hover, h5{
+a, a:hover, h5 {
   color: var(--main-link-color);
 }
 
@@ -39,11 +39,11 @@ a, a:hover, h5{
   border-color: var(--main-link-color);
 }
 
-#app{
+#app {
   color: var(--app-text-color);
 }
 
-#app .router-link-exact-active{
+#app .router-link-exact-active {
   color: var(--main-text-color);
   background-color: var(--main-bg-color);
 }
@@ -52,7 +52,7 @@ a, a:hover, h5{
   border-color: var(--main-line-color) var(--main-line-color) var(--main-bg-color);
 }
 
-.nav-tabs{
+.nav-tabs {
   border-bottom: 1px solid var(--main-line-color);
 }
 
@@ -66,7 +66,7 @@ a, a:hover, h5{
   border-bottom-width: 1px;
 }
 
-.card{
+.card {
   background-color: var(--main-bg-color);
   border:1px solid var(--main-line-color);
 }

--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -19,7 +19,7 @@
         <FavoriteStar class="mr-3" @favorite="favorited" :isFavorited="isFavorited"> </FavoriteStar>
 
         <div class="print-button">
-          <b-button variant="outline-primary" :href="`/recipe/${this.name}/print`" target="_blank">
+          <b-button variant="outline-primary" :to="`/recipe/${this.name}/print`" target="_blank">
             Print
           </b-button>
         </div>

--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -103,8 +103,8 @@
       <h4>Similar drinks</h4>
       <b-card-group deck>
         <RecipeTile
-          v-for="(similarRecipe, i) in similarRecipes"
-          v-bind:key="i"
+          v-for="similarRecipe in similarRecipes"
+          v-bind:key="similarRecipe.id"
           v-bind:id="similarRecipe.id"
         />
       </b-card-group>
@@ -137,13 +137,18 @@ export default {
     name(newVal) {
       this.getRecipe(newVal);
       window.document.title = `Open Drinks - ${this.drink.name}`;
+
+      this.getFavorites();
+      this.getSimilarRecipes(newVal).then(data => {
+        this.similarRecipes = data;
+      });
     },
   },
   data() {
     return {
       json: {},
       drink: {},
-      similarRecipes: {},
+      similarRecipes: [],
       badgeStyle: {
         'margin-right': '0.2vw',
       },
@@ -151,19 +156,21 @@ export default {
       favorites: [],
     };
   },
-  async created() {
+  created() {
     this.getRecipe(this.name);
-    window.document.title = `Open Drinks - ${this.drink.name}`;
-    this.similarRecipes = (await recipes.getSimilarRecipe(this.name)).slice(
-      0,
-      NUMBER_OF_SIMILAR_RECIPES,
-    );
-    this.favorites = JSON.parse(window.localStorage.getItem('favorites')) || [];
-    if (this.favorites.indexOf(this.drink.name) !== -1) {
-      this.isFavorited = true;
-    }
+    this.getFavorites();
+    this.getSimilarRecipes(this.name).then(data => {
+      this.similarRecipes = data;
+    });
   },
   methods: {
+    async getSimilarRecipes(name) {
+      return (await recipes.getSimilarRecipe(name)).slice(0, NUMBER_OF_SIMILAR_RECIPES);
+    },
+    getFavorites() {
+      this.favorites = JSON.parse(window.localStorage.getItem('favorites')) || [];
+      this.isFavorited = this.favorites.indexOf(this.drink.name) !== -1;
+    },
     getRecipe(name) {
       const drink = recipes.getRecipe(name);
       this.drink = drink;

--- a/src/components/RecipeFind.vue
+++ b/src/components/RecipeFind.vue
@@ -28,7 +28,7 @@
         v-on:mouseover="onMouseOverOrMove"
         v-on:mouseleave="onMouseLeave"
         v-on:mousemove="onMouseOverOrMove"
-        :href="'/recipe/' + o.filename"
+        :to="'/recipe/' + o.filename"
         >{{ o.name }}</b-list-group-item
       >
     </b-list-group>

--- a/src/components/RecipeList.vue
+++ b/src/components/RecipeList.vue
@@ -12,7 +12,7 @@
             {{ o.description }}
           </b-card-text>
 
-          <b-button :href="'/recipe/' + o.filename" variant="primary">View Recipe</b-button>
+          <b-button :to="'/recipe/' + o.filename" variant="primary">View Recipe</b-button>
           <FavoriteStar
             class="mt-2 float-right"
             @favorite="favorited(o.name)"

--- a/src/components/RecipeTile.vue
+++ b/src/components/RecipeTile.vue
@@ -2,10 +2,10 @@
   <b-card
     class="mb-4"
     style="min-width: calc( 33.333% - 30px )"
-    :href="'/recipe/' + drink.filename"
+    :to="'/recipe/' + drink.filename"
     no-body
   >
-    <b-link :href="'/recipe/' + drink.filename">
+    <b-link :to="'/recipe/' + drink.filename">
       <b-card-img-lazy
         :src="drink.image ? require(`@/assets/recipes/${drink.image}`) : null"
         :alt="drink.name"
@@ -15,7 +15,7 @@
 
     <b-card-body>
       <b-card-title>
-        <b-link :href="'/recipe/' + drink.filename">
+        <b-link :to="'/recipe/' + drink.filename">
           <h5>{{ drink.name }}</h5>
         </b-link>
       </b-card-title>


### PR DESCRIPTION
Fix routing from `:href` to `:to` to avoid reloading page while switching recipes, which was causing an issue where light theme would flash before dark theme is set again.