### PR TITLE
Fix when changing routes did not scroll to top

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -22,6 +22,10 @@ svg{
   color: var(--main-bg-color);
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   background-color: var(--main-bg-color);
 }

--- a/src/router.js
+++ b/src/router.js
@@ -63,4 +63,7 @@ export default new Router({
       component: () => import('./views/PageNotFound.vue'),
     },
   ],
+  scrollBehavior() {
+    return { x: 0, y: 0 };
+  },
 });


### PR DESCRIPTION
I didn't see an issue for this but I think it's a good update.
I updated the code so it scrolls to the top when people search and click a recipe.

![Problem](https://user-images.githubusercontent.com/5165063/96767608-a8262a00-13d4-11eb-99c6-bc09cda747a6.gif)

After the merge
![Solution](https://user-images.githubusercontent.com/5165063/96767585-9fcdef00-13d4-11eb-9678-253adcd77b0e.gif)
