### PR TITLE
Fixed spelling for white-freezie

### DIFF
--- a/src/recipes/white-freezie.json
+++ b/src/recipes/white-freezie.json
@@ -6,12 +6,12 @@
         {
             "quantity": "1",
             "measure": "oz",
-            "ingredient": "Banana Liqeuer"
+            "ingredient": "Banana Liqueur"
         },
         {
             "quantity": "1",
             "measure": "oz",
-            "ingredient": "Sour Puss Raspberry Liqeuer"
+            "ingredient": "Sour Puss Raspberry Liqueur"
         },
         {
             "quantity": "1",
@@ -21,7 +21,7 @@
     ],
     "directions": [
         "Optional: Add ice to a glass.",
-        "Pour Liqeuers into the glass.",
+        "Pour Liqueur into the glass.",
         "Fill remainder of glass with Sprite or 7-Up."
     ],
     "image": "white-freezie.jpg",


### PR DESCRIPTION
Liqueur was spelled incorrectly as "Liqeuer". This has been updated in multiple places for the white-freezie.json recipe.