### PR TITLE
Improve recipie components HTML semantics

### DIFF
--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -65,7 +65,7 @@
 
       <b-row tag="section">
         <div class="recipe-directions-list">
-          <h4>{{ $t('Directions') }}</h4>
+          <h3 class="h4">{{ $t('Directions') }}</h3>
           <ol class="mb-4">
             <li v-for="(o, i) in drink.directions" v-bind:key="i">{{ o }}</li>
           </ol>


### PR DESCRIPTION
This PR aims to improve the HTML semantics in the component Recipe.vue.

Make use of article, header, ul for tags, address for contributor and sections.
Also changed h4 to h2 due to incorrect heading jump from h1 to h4 - https://web.dev/heading-order/