### PR TITLE
Add FabButton for Bottom To Top

### DIFF
--- a/src/components/FabButton.vue
+++ b/src/components/FabButton.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="fab-wrapper" @click="scrollTop">
+    <a href="#" class="fab-button">
+      <p>TOP</p>
+    </a>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'FabButton',
+  methods: {
+    scrollTop() {
+      console.log('scroll top');
+      window.scrollTo(0, 0);
+    },
+  },
+};
+</script>
+
+<style scoped>
+/*FAB Styles*/
+.fab-wrapper {
+  position: fixed;
+  right: 50px;
+  bottom: 50px;
+  z-index: 5;
+  display: flex;
+  flex-direction: center;
+  justify-content: center;
+  align-items: center;
+}
+.fab-button {
+  width: 70px;
+  height: 70px;
+  background: var(--main-link-color) !important;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+  outline: none;
+}
+.fab-button:hover {
+  text-decoration: none;
+}
+
+.fab-button p {
+  font-size: 20px;
+  font-weight: 700;
+  color: #fff;
+  margin: 0;
+}
+</style>

--- a/src/views/Featured.vue
+++ b/src/views/Featured.vue
@@ -1,16 +1,19 @@
 <template>
   <div class="featured container">
     <FeaturedRecipes />
+    <FabButton />
   </div>
 </template>
 
 <script>
 import FeaturedRecipes from '@/components/FeaturedRecipes.vue';
+import FabButton from '@/components/FabButton.vue';
 
 export default {
   name: 'home',
   components: {
     FeaturedRecipes,
+    FabButton,
   },
 };
 </script>


### PR DESCRIPTION
## Purpose

Solves issue #1182.

## Changes

Added a FabButton component. This component can be added to any page. 
The Fab Button sits in bottom right corner of screen as user scrolls down. If they click on it it will scroll the page back to the top. 

Currently this component is only on the Featured (home) page of the application. It can be added to any page and will work.
